### PR TITLE
Do not assume activesupport

### DIFF
--- a/lib/tuktuk/tuktuk.rb
+++ b/lib/tuktuk/tuktuk.rb
@@ -118,7 +118,7 @@ module Tuktuk
       mail.destinations.each do |to|
 
         domain = get_domain(to)
-        raise "Empty domain: #{domain}" if domain.blank?
+        raise "Empty domain: #{domain}" if domain.to_s.strip == ''
 
         unless servers = smtp_servers_for_domain(domain)
           return HardBounce.new("588 No MX records for domain #{domain}")

--- a/spec/deliver_spec.rb
+++ b/spec/deliver_spec.rb
@@ -169,7 +169,7 @@ describe 'deliver many' do
             it 'does not try to send that same email to second server' do
               Tuktuk.should_receive(:send_many_now).once.with('mx1.domain.com', @emails).and_return([@first])
               last_two_emails = @emails.last(2)
-              last_two_emails.include?(@emails.first).should be_false
+              last_two_emails.include?(@emails.first).should be false
               Tuktuk.should_receive(:send_many_now).once.with('mx2.domain.com', last_two_emails).and_return(@last_two)
               Tuktuk.should_not_receive(:send_many_now).with('mx3.domain.com')
               Tuktuk.send(:lookup_and_deliver_by_domain, 'domain.com', @emails)


### PR DESCRIPTION
## What

This gem was using `String#blank?`, which is an ActiveSupport thing. ActiveSupport is not declared as a dependency here.

Remove the use of `#blank?`.
