### PR TITLE
Fixes certificate verification failures (Closes #4)

### DIFF
--- a/lib/tuktuk/tuktuk.rb
+++ b/lib/tuktuk/tuktuk.rb
@@ -282,6 +282,7 @@ module Tuktuk
       context = OpenSSL::SSL::SSLContext.new
       context.verify_mode = config[:verify_ssl] ?
         OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
+      context.set_params # Configures default certificate store
 
       port = nil
       if config[:debug]


### PR DESCRIPTION
In some cases, like with LetsEncrypt, a "certificate verify failed" error could be raised. This commit calls the `set_params` method on the `OpenSSL::SSL::SSLContext` instance configuring default options, including the `cert_store` so that it uses local CA certificates to remote certificates.